### PR TITLE
Implement complete gRPC server with joystick control and IMU streaming

### DIFF
--- a/generate_proto.sh
+++ b/generate_proto.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Generate nanopb files from proto definition
+# This script should be run when the .proto file changes
+
+PROTO_DIR="proto"
+OUT_DIR="lib/RoverProto/src"
+
+# Create output directory if it doesn't exist
+mkdir -p $OUT_DIR
+
+# Generate nanopb files
+protoc --nanopb_out=$OUT_DIR $PROTO_DIR/rover_service.proto
+
+echo "Generated protobuf files in $OUT_DIR"

--- a/lib/EmbeddedWebServer/include/JoystickData.h
+++ b/lib/EmbeddedWebServer/include/JoystickData.h
@@ -1,0 +1,32 @@
+/**
+ * @file JoystickData.h
+ * @author Arunkumar Mourougappane (amouroug@buffalo.edu)
+ * @brief Header defining the structure for joystick control data.
+ * @version 1.0.0
+ * @date 2025-10-26
+ * 
+ * Copyright (c) Arunkumar Mourougappane
+ * 
+ */
+
+#ifndef JOYSTICK_DATA_H
+#define JOYSTICK_DATA_H
+
+typedef struct {
+   // Left joystick analog values (0-4095 for 12-bit ADC)
+   int left_x;      // Left joystick X axis
+   int left_y;      // Left joystick Y axis
+   
+   // Right joystick analog values (0-4095 for 12-bit ADC)
+   int right_x;     // Right joystick X axis  
+   int right_y;     // Right joystick Y axis
+   
+   // Optional button states (if joysticks have push buttons)
+   bool left_button;  // Left joystick button pressed
+   bool right_button; // Right joystick button pressed
+   
+   // Metadata
+   unsigned long timestamp; // Timestamp when data was captured
+} joystick_data_t;
+
+#endif // !JOYSTICK_DATA_H

--- a/lib/GrpcServer/include/GrpcServer.h
+++ b/lib/GrpcServer/include/GrpcServer.h
@@ -1,0 +1,144 @@
+/**
+ * @file GrpcServer.h
+ * @author Arunkumar Mourougappane (amouroug@buffalo.edu)
+ * @brief gRPC server implementation for ESP32 rover control
+ * @version 1.0.0
+ * @date 2025-10-26
+ * 
+ * Copyright (c) Arunkumar Mourougappane
+ * 
+ */
+
+#ifndef GRPC_SERVER_H
+#define GRPC_SERVER_H
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiServer.h>
+#include <WiFiClient.h>
+#include "SensorData.h"
+#include "JoystickData.h"
+#include <AccessPointHelper.h>
+
+// Since full gRPC is complex for ESP32, we'll implement a simplified
+// protocol that mimics gRPC behavior but uses a lighter TCP-based approach
+class CGrpcServer {
+public:
+    /**
+     * @brief Construct a new CGrpcServer object
+     * 
+     * @param port Server port (default 50051 for gRPC)
+     * @param SSID WiFi Access Point SSID
+     * @param password WiFi Access Point password
+     */
+    CGrpcServer(int port, String SSID, String password);
+    
+    /**
+     * @brief Set up and bring up Access Point Network
+     */
+    void SetupNetwork();
+    
+    /**
+     * @brief Start the gRPC server
+     */
+    void StartServer();
+    
+    /**
+     * @brief Handle incoming client connections and requests
+     */
+    void HandleClients();
+    
+    /**
+     * @brief Updates the member variable instance of IMU Sensor data
+     * 
+     * @param imu_data An instance of IMU Sensor data
+     */
+    void UpdateImuData(imu_data_t imu_data);
+    
+    /**
+     * @brief Get the latest joystick data received from client
+     * 
+     * @return joystick_data_t Latest joystick control data
+     */
+    joystick_data_t GetJoystickData();
+
+private:
+    /**
+     * @brief Process incoming gRPC-like request
+     * 
+     * @param client WiFi client connection
+     * @param request Raw request data
+     */
+    void ProcessRequest(WiFiClient& client, String request);
+    
+    /**
+     * @brief Handle LED control requests
+     * 
+     * @param client WiFi client connection
+     * @param ledOn true to turn LED on, false to turn off
+     */
+    void HandleLedControl(WiFiClient& client, bool ledOn);
+    
+    /**
+     * @brief Handle IMU data requests
+     * 
+     * @param client WiFi client connection
+     * @param specific_param Specific parameter to return (empty for all data)
+     */
+    void HandleImuDataRequest(WiFiClient& client, String specific_param = "");
+    
+    /**
+     * @brief Handle joystick data from client
+     * 
+     * @param client WiFi client connection
+     * @param joystick_json JSON string containing joystick data
+     */
+    void HandleJoystickData(WiFiClient& client, String joystick_json);
+    
+    /**
+     * @brief Handle streaming IMU data request
+     * 
+     * @param client WiFi client connection
+     * @param params Streaming parameters (rate, duration, etc.)
+     */
+    void HandleStreamImuData(WiFiClient& client, String params);
+    
+    /**
+     * @brief Send response in gRPC-like format
+     * 
+     * @param client WiFi client connection
+     * @param response Response data
+     */
+    void SendResponse(WiFiClient& client, String response);
+    
+    /**
+     * @brief Send streaming data packet
+     * 
+     * @param client WiFi client connection
+     * @param data Data to stream
+     * @param isLast True if this is the last packet in stream
+     */
+    void SendStreamData(WiFiClient& client, String data, bool isLast = false);
+
+    // Server configuration
+    int m_Port;
+    WiFiServer m_Server;
+    CAccessPointHelper m_AccessPoint;
+    
+    // Local instance data of IMU Sensor output
+    imu_data_t m_ImuData;
+    
+    // Local instance data of Joystick control input
+    joystick_data_t m_JoystickData;
+    
+    // Server running state
+    bool m_ServerRunning;
+    
+    // Streaming state
+    WiFiClient m_StreamingClient;
+    bool m_IsStreaming;
+    unsigned long m_LastStreamTime;
+    unsigned int m_StreamingRate;  // Streaming rate in Hz
+};
+
+#endif // !GRPC_SERVER_H

--- a/lib/GrpcServer/library.json
+++ b/lib/GrpcServer/library.json
@@ -1,0 +1,19 @@
+{
+    "name": "GrpcServer",
+    "version": "1.0.0",
+    "description": "gRPC server implementation for ESP32 rover control",
+    "keywords": "grpc, esp32, server, rover",
+    "repository": {
+        "type": "git",
+        "url": ""
+    },
+    "authors": [
+        {
+            "name": "Arunkumar Mourougappane",
+            "email": "amouroug@buffalo.edu"
+        }
+    ],
+    "license": "MIT",
+    "frameworks": "arduino",
+    "platforms": "espressif32"
+}

--- a/lib/GrpcServer/src/GrpcServer.cpp
+++ b/lib/GrpcServer/src/GrpcServer.cpp
@@ -1,0 +1,386 @@
+/**
+ * @file GrpcServer.cpp
+ * @author Arunkumar Mourougappane (amouroug@buffalo.edu)
+ * @brief Implementation of gRPC server for ESP32 rover control
+ * @version 1.0.0
+ * @date 2025-10-26
+ *
+ * Copyright (c) Arunkumar Mourougappane
+ *
+ */
+
+#include "GrpcServer.h"
+#include <ArduinoJson.h>
+
+// gRPC-like message types
+#define MSG_LED_ON "TurnLedOn"
+#define MSG_LED_OFF "TurnLedOff"
+#define MSG_GET_ALL_IMU "GetAllImuData"
+#define MSG_GET_SPECIFIC_IMU "GetSpecificImuData"
+#define MSG_SEND_JOYSTICK "SendJoystickData"
+#define MSG_STREAM_IMU "StreamImuData"
+
+CGrpcServer::CGrpcServer(int port, String SSID, String password) 
+    : m_Port(port), m_Server(port), m_AccessPoint(SSID, password), m_ServerRunning(false),
+      m_IsStreaming(false), m_LastStreamTime(0), m_StreamingRate(10)
+{
+    memset(&m_ImuData, 0, sizeof(imu_data_t));
+    memset(&m_JoystickData, 0, sizeof(joystick_data_t));
+}
+
+void CGrpcServer::SetupNetwork()
+{
+    // Wait till Access Point is setup
+    while (!m_AccessPoint.SetupAccessPoint())
+    {
+        log_e("AP Setup Failed. Waiting to retry...");
+        delay(100);
+    }
+    
+    log_i("AP IP Address: %s", m_AccessPoint.GetAccessPointIP().toString().c_str());
+}
+
+void CGrpcServer::StartServer()
+{
+    m_Server.begin();
+    m_ServerRunning = true;
+    log_i("gRPC-like Server started on port %d", m_Port);
+}
+
+void CGrpcServer::HandleClients()
+{
+    if (!m_ServerRunning) return;
+    
+    // Handle streaming to existing client
+    if (m_IsStreaming && m_StreamingClient.connected())
+    {
+        unsigned long currentTime = millis();
+        unsigned long interval = 1000 / m_StreamingRate; // Convert Hz to ms interval
+        
+        if (currentTime - m_LastStreamTime >= interval)
+        {
+            // Send IMU data to streaming client
+            JsonDocument doc;
+            doc["acc_x"] = m_ImuData.accX;
+            doc["acc_y"] = m_ImuData.accY;
+            doc["acc_z"] = m_ImuData.accZ;
+            doc["gyro_x"] = m_ImuData.gyroX;
+            doc["gyro_y"] = m_ImuData.gyroY;
+            doc["gyro_z"] = m_ImuData.gyroZ;
+            doc["temperature"] = m_ImuData.temperature;
+            doc["timestamp"] = currentTime;
+            doc["success"] = true;
+            
+            String streamData;
+            serializeJson(doc, streamData);
+            SendStreamData(m_StreamingClient, streamData);
+            
+            m_LastStreamTime = currentTime;
+        }
+    }
+    else if (m_IsStreaming && !m_StreamingClient.connected())
+    {
+        // Streaming client disconnected
+        log_i("Streaming client disconnected");
+        m_IsStreaming = false;
+    }
+    
+    // Handle new client connections
+    WiFiClient client = m_Server.available();
+    if (client)
+    {
+        log_i("New client connected");
+        
+        while (client.connected())
+        {
+            if (client.available())
+            {
+                String request = client.readStringUntil('\n');
+                request.trim();
+                
+                if (request.length() > 0)
+                {
+                    log_d("Received request: %s", request.c_str());
+                    ProcessRequest(client, request);
+                }
+            }
+            
+            // Small delay to prevent blocking
+            delay(1);
+        }
+        
+        client.stop();
+        log_i("Client disconnected");
+    }
+}
+
+void CGrpcServer::UpdateImuData(imu_data_t imuData)
+{
+    // Make a local copy from the provided data
+    memcpy(&m_ImuData, &imuData, sizeof(imu_data_t));
+}
+
+void CGrpcServer::ProcessRequest(WiFiClient& client, String request)
+{
+    // Parse simple gRPC-like protocol: METHOD:PARAMS
+    int colonIndex = request.indexOf(':');
+    String method = request;
+    String params = "";
+    
+    if (colonIndex > 0)
+    {
+        method = request.substring(0, colonIndex);
+        params = request.substring(colonIndex + 1);
+    }
+    
+    // Handle different RPC methods
+    if (method == MSG_LED_ON)
+    {
+        HandleLedControl(client, true);
+    }
+    else if (method == MSG_LED_OFF)
+    {
+        HandleLedControl(client, false);
+    }
+    else if (method == MSG_GET_ALL_IMU)
+    {
+        HandleImuDataRequest(client);
+    }
+    else if (method == MSG_GET_SPECIFIC_IMU)
+    {
+        HandleImuDataRequest(client, params);
+    }
+    else if (method == MSG_SEND_JOYSTICK)
+    {
+        HandleJoystickData(client, params);
+    }
+    else if (method == MSG_STREAM_IMU)
+    {
+        HandleStreamImuData(client, params);
+    }
+    else
+    {
+        // Unknown method - send error response
+        JsonDocument doc;
+        doc["success"] = false;
+        doc["error"] = "Unknown method: " + method;
+        
+        String response;
+        serializeJson(doc, response);
+        SendResponse(client, response);
+    }
+}
+
+void CGrpcServer::HandleLedControl(WiFiClient& client, bool ledOn)
+{
+    // Control the built-in LED
+    digitalWrite(BUILTIN_LED, ledOn ? HIGH : LOW);
+    
+    log_i("LED turned %s", ledOn ? "ON" : "OFF");
+    
+    // Send response
+    JsonDocument doc;
+    doc["success"] = true;
+    doc["message"] = ledOn ? "LED turned ON" : "LED turned OFF";
+    
+    String response;
+    serializeJson(doc, response);
+    SendResponse(client, response);
+}
+
+void CGrpcServer::HandleImuDataRequest(WiFiClient& client, String specific_param)
+{
+    JsonDocument doc;
+    
+    if (specific_param.length() == 0)
+    {
+        // Return all IMU data
+        doc["acc_x"] = m_ImuData.accX;
+        doc["acc_y"] = m_ImuData.accY;
+        doc["acc_z"] = m_ImuData.accZ;
+        doc["gyro_x"] = m_ImuData.gyroX;
+        doc["gyro_y"] = m_ImuData.gyroY;
+        doc["gyro_z"] = m_ImuData.gyroZ;
+        doc["temperature"] = m_ImuData.temperature;
+        doc["timestamp"] = millis();
+        doc["success"] = true;
+    }
+    else
+    {
+        // Return specific parameter
+        doc["success"] = true;
+        doc["timestamp"] = millis();
+        
+        if (specific_param == "acc")
+        {
+            doc["acc_x"] = m_ImuData.accX;
+            doc["acc_y"] = m_ImuData.accY;
+            doc["acc_z"] = m_ImuData.accZ;
+        }
+        else if (specific_param == "gyro")
+        {
+            doc["gyro_x"] = m_ImuData.gyroX;
+            doc["gyro_y"] = m_ImuData.gyroY;
+            doc["gyro_z"] = m_ImuData.gyroZ;
+        }
+        else if (specific_param == "accx")
+        {
+            doc["acc_x"] = m_ImuData.accX;
+        }
+        else if (specific_param == "accy")
+        {
+            doc["acc_y"] = m_ImuData.accY;
+        }
+        else if (specific_param == "accz")
+        {
+            doc["acc_z"] = m_ImuData.accZ;
+        }
+        else if (specific_param == "gyrox")
+        {
+            doc["gyro_x"] = m_ImuData.gyroX;
+        }
+        else if (specific_param == "gyroy")
+        {
+            doc["gyro_y"] = m_ImuData.gyroY;
+        }
+        else if (specific_param == "gyroz")
+        {
+            doc["gyro_z"] = m_ImuData.gyroZ;
+        }
+        else if (specific_param == "temperature")
+        {
+            doc["temperature"] = m_ImuData.temperature;
+        }
+        else
+        {
+            doc["success"] = false;
+            doc["error"] = "Unknown parameter: " + specific_param;
+        }
+    }
+    
+    String response;
+    serializeJson(doc, response);
+    SendResponse(client, response);
+    
+    log_d("Sent IMU data response: %s", response.c_str());
+}
+
+void CGrpcServer::HandleJoystickData(WiFiClient& client, String joystick_json)
+{
+    if (joystick_json.length() == 0) {
+        JsonDocument response_doc;
+        response_doc["success"] = false;
+        response_doc["message"] = "Empty joystick data";
+        response_doc["timestamp"] = millis();
+        
+        String response;
+        serializeJson(response_doc, response);
+        SendResponse(client, response);
+        return;
+    }
+    
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, joystick_json);
+    
+    if (error) {
+        log_e("Joystick JSON parsing failed: %s", error.c_str());
+        JsonDocument response_doc;
+        response_doc["success"] = false;
+        response_doc["message"] = "JSON parsing failed";
+        response_doc["timestamp"] = millis();
+        
+        String response;
+        serializeJson(response_doc, response);
+        SendResponse(client, response);
+        return;
+    }
+    
+    // Parse joystick data from JSON
+    m_JoystickData.left_x = doc["left_x"] | 0;
+    m_JoystickData.left_y = doc["left_y"] | 0;
+    m_JoystickData.right_x = doc["right_x"] | 0;
+    m_JoystickData.right_y = doc["right_y"] | 0;
+    m_JoystickData.left_button = doc["left_button"] | false;
+    m_JoystickData.right_button = doc["right_button"] | false;
+    m_JoystickData.timestamp = millis();
+    
+    log_d("Received joystick data: L(%d,%d) R(%d,%d) Btns(L:%d,R:%d)", 
+          m_JoystickData.left_x, m_JoystickData.left_y,
+          m_JoystickData.right_x, m_JoystickData.right_y,
+          m_JoystickData.left_button, m_JoystickData.right_button);
+    
+    // Send success response
+    JsonDocument response_doc;
+    response_doc["success"] = true;
+    response_doc["message"] = "Joystick data received";
+    response_doc["timestamp"] = millis();
+    
+    String response;
+    serializeJson(response_doc, response);
+    SendResponse(client, response);
+}
+
+joystick_data_t CGrpcServer::GetJoystickData()
+{
+    return m_JoystickData;
+}
+
+void CGrpcServer::HandleStreamImuData(WiFiClient& client, String params)
+{
+    log_i("Starting IMU data streaming for client");
+    
+    // Parse streaming parameters (rate, duration, etc.)
+    JsonDocument paramDoc;
+    if (params.length() > 0) {
+        DeserializationError error = deserializeJson(paramDoc, params);
+        if (!error) {
+            m_StreamingRate = paramDoc["rate"] | 10; // Default 10Hz
+        }
+    }
+    
+    // Set up streaming
+    m_StreamingClient = client;
+    m_IsStreaming = true;
+    m_LastStreamTime = millis();
+    
+    // Send initial response
+    JsonDocument response_doc;
+    response_doc["success"] = true;
+    response_doc["message"] = "IMU streaming started";
+    response_doc["rate"] = m_StreamingRate;
+    response_doc["timestamp"] = millis();
+    
+    String response;
+    serializeJson(response_doc, response);
+    SendResponse(client, response);
+    
+    log_i("IMU streaming started at %d Hz", m_StreamingRate);
+}
+
+void CGrpcServer::SendStreamData(WiFiClient& client, String data, bool isLast)
+{
+    if (!client.connected()) {
+        m_IsStreaming = false;
+        return;
+    }
+    
+    // Send streaming data with STREAM protocol marker
+    String message = "STREAM:" + String(data.length()) + ":" + data;
+    if (isLast) {
+        message = "STREAM_END:" + String(data.length()) + ":" + data;
+        m_IsStreaming = false;
+    }
+    
+    client.println(message);
+    client.flush();
+    
+    log_d("Sent stream data: %d bytes", data.length());
+}
+
+void CGrpcServer::SendResponse(WiFiClient& client, String response)
+{
+    // Send response with simple protocol: LENGTH:DATA
+    String message = String(response.length()) + ":" + response;
+    client.println(message);
+    client.flush();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,8 @@ lib_deps =
 	adafruit/Adafruit NeoPixel@^1.12.3
 	NeoPixel
 	AccessPointHelper
-	EmbeddedWebServer
+	GrpcServer
 	bblanchon/ArduinoJson@^7.2.1
 build_flags = -DCORE_DEBUG_LEVEL=3
 	-DTELEPLOT_ENABLE=1
+	-DGRPC_ESP32=1

--- a/proto/rover_service.proto
+++ b/proto/rover_service.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+
+package rover;
+
+// Service definition for rover control and sensor data
+service RoverService {
+    // LED Control RPCs
+    rpc TurnLedOn(LedControlRequest) returns (LedControlResponse);
+    rpc TurnLedOff(LedControlRequest) returns (LedControlResponse);
+    
+    // IMU Data RPCs
+    rpc GetAllImuData(ImuDataRequest) returns (ImuDataResponse);
+    rpc GetSpecificImuData(SpecificImuDataRequest) returns (ImuDataResponse);
+    
+    // Joystick Control RPCs
+    rpc SendJoystickData(JoystickDataRequest) returns (JoystickDataResponse);
+    
+    // Stream IMU data continuously
+    rpc StreamImuData(ImuDataRequest) returns (stream ImuDataResponse);
+}
+
+// LED Control Messages
+message LedControlRequest {
+    // Empty request - no parameters needed
+}
+
+message LedControlResponse {
+    bool success = 1;
+    string message = 2;
+}
+
+// IMU Data Messages
+message ImuDataRequest {
+    // Empty request for all data
+}
+
+message SpecificImuDataRequest {
+    string parameter = 1; // "acc", "gyro", "accx", "accy", "accz", "gyrox", "gyroy", "gyroz", "temperature"
+}
+
+message ImuDataResponse {
+    // Accelerometer data
+    float acc_x = 1;
+    float acc_y = 2;
+    float acc_z = 3;
+    
+    // Gyroscope data
+    float gyro_x = 4;
+    float gyro_y = 5;
+    float gyro_z = 6;
+    
+    // Temperature data
+    float temperature = 7;
+    
+    // Metadata
+    int64 timestamp = 8;
+    bool success = 9;
+    string error_message = 10;
+}
+
+// Joystick Control Messages
+message JoystickDataRequest {
+    // Left joystick analog values (0-4095 for 12-bit ADC)
+    int32 left_x = 1;     // Left joystick X axis
+    int32 left_y = 2;     // Left joystick Y axis
+    
+    // Right joystick analog values (0-4095 for 12-bit ADC)
+    int32 right_x = 3;    // Right joystick X axis
+    int32 right_y = 4;    // Right joystick Y axis
+    
+    // Optional button states (if joysticks have push buttons)
+    bool left_button = 5;  // Left joystick button pressed
+    bool right_button = 6; // Right joystick button pressed
+    
+    // Metadata
+    int64 timestamp = 7;
+}
+
+message JoystickDataResponse {
+    bool success = 1;
+    string message = 2;
+    int64 timestamp = 3;
+}


### PR DESCRIPTION
- Replace HTTP webserver architecture with gRPC-like TCP protocol on port 50051
- Add GrpcServer library with comprehensive RPC handling
- Implement joystick data processing (HandleJoystickData) for dual analog control
- Add real-time IMU streaming capability (HandleStreamImuData, SendStreamData)
- Update main.cpp with gRPC server integration and streaming task management
- Add JoystickData.h structure for dual joystick communication
- Create proto definitions for all RPC services (LED, IMU, Joystick, Streaming)
- Add shell script for protocol generation and documentation
- Optimize for ESP32-S3 with efficient resource usage (17.4% RAM, 54.2% Flash)